### PR TITLE
Update About/SEO copy to 13 years experience

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,7 +10,7 @@ export default function Home() {
           <span className="font-semibold text-primary-light dark:text-primary-dark">
             Senior Full-stack Engineer
           </span>{' '}
-          at Toptal with 12 years of experience building and maintaining robust
+          at Toptal with 13 years of experience building and maintaining robust
           web applications.
         </p>
         <p className="mb-4">
@@ -25,12 +25,14 @@ export default function Home() {
           architecture call for it, I lean on .NET.
         </p>
         <p>
-          With over 6 years of remote work experience, I thrive in distributed
+          With over 7 years of remote work experience, I thrive in distributed
           teams and bring a reliable, self-directed work ethic to every project.
         </p>
       </section>
       <section className="w-full max-w-4xl mx-auto">
-        <h2 className="text-3xl font-bold mb-8 w-full text-center">Work History</h2>
+        <h2 className="text-3xl font-bold mb-8 w-full text-center">
+          Work History
+        </h2>
         <WorkHistory />
       </section>
     </>

--- a/src/data/constants.ts
+++ b/src/data/constants.ts
@@ -1,9 +1,9 @@
 export const SEO = {
   title: 'Francois Laubscher | Senior Full-stack Engineer',
-  description: `I'm a Senior Full-stack Engineer at Toptal with 12 years of experience building and maintaining robust web applications.`,
+  description: `I'm a Senior Full-stack Engineer at Toptal with 13 years of experience building and maintaining robust web applications.`,
   openGraph: {
     title: 'Francois Laubscher | Senior Full-stack Engineer',
-    description: `I'm a Senior Full-stack Engineer at Toptal with 12 years of experience building and maintaining robust web applications.`,
+    description: `I'm a Senior Full-stack Engineer at Toptal with 13 years of experience building and maintaining robust web applications.`,
     image: 'me.png',
     url: 'https://francoislaubscher.dev',
   },


### PR DESCRIPTION
### Motivation
- Reflect the correct professional tenure by updating the public About copy and SEO/open-graph metadata from 12 years to 13 years of experience and adjust remote-work text to match the August 2018 remote start.

### Description
- Updated `src/app/page.tsx` to change the About copy from `12 years` to `13 years` and from `With over 6 years` remote to `With over 7 years` remote.
- Updated `src/data/constants.ts` SEO `description` and `openGraph.description` to use `13 years` of experience so meta tags match the page copy.
- Ran project formatting which adjusted minor whitespace in `src/app/page.tsx`.

### Testing
- Ran `npm run format` which completed successfully and formatted changed files.
- Ran `npx tsc --noEmit` which failed due to missing project dependencies in this environment (dependency installation blocked).
- Ran `npm run lint` and `npm run build` which failed because the `next` binary and other dependencies are not installed in this environment.
- Attempted `npm install` to resolve dependencies but the registry request was blocked with HTTP 403, preventing further local validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d629d6b08832680d91324098b886d)